### PR TITLE
Run tests on PR opened

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: Unit Tests
-on: push
+on: 
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:


### PR DESCRIPTION
Currently looks like tests run after a merge. Changing to run on PR should reduce broken code getting merged.