### PR TITLE
Tidy footer links

### DIFF
--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -48,7 +48,7 @@
     {% if custom_footer %}
         {{ custom_footer | safe }}
     {% else %}
-        Powered by <a href="https://docs.microblog.pub">microblog.pub</a> <small class="microblogpub-version"><code>{{ microblogpub_version }}</code></small> (<a href="https://github.com/JD557/microblog.pub">source code</a>) and the <a href="https://activitypub.rocks/">ActivityPub</a> protocol. <a href="{{ url_for("login") }}">Admin</a>.
+        Powered by <a href="https://docs.microblog.pub">microblog.pub</a> <small class="microblogpub-version"><code>{{ microblogpub_version }}</code></small> (<a href="https://github.com/microblog-pub/microblog.pub">source code</a>) and the <a href="https://activitypub.rocks/">ActivityPub</a> protocol.
     {% endif %}
     </div>
 </footer>


### PR DESCRIPTION
Fix link to repo.

Also, I removed the admin link from the footer - it feels unnecessary to have that link on every single page give how infrequently it's used, and also always feels like a slightly bad idea to advertise anything admin related on the homepage.