### PR TITLE
Extended capacity to fully tailor the SCSS by creating the /data/scss/main.scss file

### DIFF
--- a/app/scss/_theme.scss
+++ b/app/scss/_theme.scss
@@ -1,1 +1,1 @@
-../../data/_theme.scss
+../../data/scss/_theme.scss

--- a/app/scss/boussole.json
+++ b/app/scss/boussole.json
@@ -1,6 +1,6 @@
 {
-    "SOURCES_PATH": "app/scss",
-    "TARGET_PATH": "app/static/css",
+    "SOURCES_PATH": ".",
+    "TARGET_PATH": "../static/css",
     "LIBRARY_PATHS": [],
     "OUTPUT_STYLES": "nested",
     "SOURCE_COMMENTS": false,

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -162,16 +162,21 @@ Do not use exotic characters in filename - only letters, numbers, and underscore
 
 The CSS is written with [SCSS](https://sass-lang.com/documentation/syntax).
 
-You can override colors by editing `data/_theme.scss`:
+You can override colors by editing `data/scss/_theme.scss`:
 
 ```scss
 $primary-color: #e14eea;                                                                            
 $secondary-color: #32cd32;
 ```
-
 See `app/scss/main.scss` to see what variables can be overridden.
 
-You will need to [recompile CSS](#recompiling-css-files) after doing any CSS changes (for actual css files to be updates) and restart microblog.pub (for css link in HTML documents to be updated with a new checksum - otherwise, browsers that downloaded old CSS will keep using it).
+But you can also rewrite your own `data/scss/main.scss`; which means, if that file is found, it will be used instead of the one inside `app/scss`.
+If you want to go this route, you will also need to copy the `app/scss/boussole.json` file inside that `data/scss/` and change the first line to:
+
+```"SOURCES_PATH": "data/scss"```
+
+You will need to [recompile CSS](#recompiling-css-files) after doing any CSS changes (for actual css files to be updates). 
+It is also recommended to restart microblog.pub so the css link in HTML documents to be updated with a new checksum (otherwise, browsers that downloaded old CSS will keep using it).
 
 #### Custom favicon
 

--- a/tasks.py
+++ b/tasks.py
@@ -84,14 +84,20 @@ def compile_scss(ctx, watch=False):
     else:
         shutil.copy2(favicon_file, "app/static/favicon.ico")
 
-    theme_file = Path("data/_theme.scss")
-    if not theme_file.exists():
-        theme_file.write_text("// override vars for theming here")
+    command = "compile"
+    config_file = "app/scss/boussole.json"
+    user_theme_file = Path("data/scss/_theme.scss")
+    user_css_file = Path("data/scss/main.scss")
+
+    if not user_theme_file.exists():
+        user_theme_file.write_text("// override vars for theming here")
+
+    if user_css_file.exists():
+        config_file = "data/scss/boussole.json"
 
     if watch:
-        run("boussole watch", echo=True)
-    else:
-        run("boussole compile", echo=True)
+        command = "watch"
+    run("boussole {} --config {}".format(command, config_file), echo=True)
 
 
 @task


### PR DESCRIPTION
Previously, one could only change the `theme` of the SCSS, which contains a small set of variables used by the `main.css`. To do so, one must create a `_theme.scss` under the `data` directory (the one with all personal material).

This PR changes how the `main.css` is produced by the task `compile-scss` to look not only for the previous `_theme` file but also a full `main.scss` file under the `data/scss/` directory. It uses the `_theme.scss` as before, but if it finds the `main` file, it will ignore the `app/static/scss` one and work with the personal version one.